### PR TITLE
Verify data on creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ assert!(!gcs.contains(b"charlie"));
 // Reduces memory footprint in exchange for slower querying
 let gcs = gcs.pack();
 
-assert!(gcs.contains(b"alpha").unwrap());
-assert!(gcs.contains(b"bravo").unwrap());
-assert!(!gcs.contains(b"charlie").unwrap());
+assert!(gcs.contains(b"alpha"));
+assert!(gcs.contains(b"bravo"));
+assert!(!gcs.contains(b"charlie"));
 ```

--- a/benches/insert.rs
+++ b/benches/insert.rs
@@ -32,7 +32,7 @@ fn insert_packed(c: &mut Criterion) {
         b.iter(|| {
             let mut buf = [0u8; 128];
             rng.fill_bytes(&mut buf);
-            let mut unpacked = packed.clone().unpack().unwrap();
+            let mut unpacked = packed.clone().unpack();
             unpacked.insert(&buf[..]).unwrap();
             let _packed = unpacked.pack();
         })

--- a/examples/collisions.rs
+++ b/examples/collisions.rs
@@ -28,7 +28,7 @@ fn main() {
     let mut buf = [0u8; 4];
     for _ in 0..TRIES {
         prng.fill_bytes(&mut buf);
-        if gcs.contains(&buf).unwrap() {
+        if gcs.contains(&buf) {
             // None of the values we are trying were inserted, so any present
             // are false positives
             num += 1;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -25,7 +25,7 @@ proptest! {
             unpacked.pack()
         };
 
-        assert!(gcs.contains(&bytes).unwrap());
+        assert!(gcs.contains(&bytes));
     }
 
     #[test]
@@ -53,7 +53,7 @@ proptest! {
             unpacked.pack()
         };
 
-        assert!(!gcs.contains(&b).unwrap());
+        assert!(!gcs.contains(&b));
     }
 
     // Tests the packing/unpacking roundtrip
@@ -68,6 +68,6 @@ proptest! {
             gcs.insert(elem).unwrap();
         }
 
-        assert_eq!(gcs, gcs.pack().unpack().unwrap());
+        assert_eq!(gcs, gcs.pack().unpack());
     }
 }

--- a/tests/rasky.rs
+++ b/tests/rasky.rs
@@ -158,7 +158,7 @@ fn uuids_short_query_packed() {
 
     for line in file.lines() {
         let l = line.unwrap();
-        assert!(gcs.contains(l.as_bytes()).unwrap())
+        assert!(gcs.contains(l.as_bytes()))
     }
 }
 
@@ -183,6 +183,6 @@ fn uuids_1000_query_packed() {
 
     for line in file.lines() {
         let l = line.unwrap();
-        assert!(gcs.contains(l.as_bytes()).unwrap())
+        assert!(gcs.contains(l.as_bytes()))
     }
 }


### PR DESCRIPTION
Closes #24.

Decreases `Gcs::from_reader` speed, but means `contains` and `unpack` do not need to return a result.